### PR TITLE
change img1 and img2 comparison algorithm from getbbox() to imagecompare.is_equal()

### DIFF
--- a/AutoScreenShot.py
+++ b/AutoScreenShot.py
@@ -16,6 +16,7 @@ import tkinter as tk
 from tkinter import *
 from tkinter import font
 
+import imgcompare
 
 class AutoScreenshot:
     def __init__(self, master):
@@ -70,25 +71,35 @@ class AutoScreenshot:
         img1.save(fname)
         print("First Screenshot taken")
 
+        # maintain a reference image
+        self.ref_img = img1 
+
         # start taking screenshot of next images
         self.take_screenshots()       
 
     def take_screenshots(self):
+        #imgcompare param
+        tolerance = 5
+
+
         # grab first and second image
-        img1 = grab(bbox=self.cords)
-        time.sleep(1)
+        # img1 now becomes self.img1, to have a consistent ref
+        time.sleep(1) # check screen every x seconds
         img2 = grab(bbox=self.cords)
 
         # check difference between images
-        diff = ImageChops.difference(img1, img2)
-        bbox = diff.getbbox()
+        # use imgcompare percent difference
+        img_is_equal = imgcompare.is_equal(self.ref_img, img2, tolerance)
+
         
-        if bbox is not None:
+        if img_is_equal == False:
             now = datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p")
             fname = self.new_folder + "/ScreenShots" + now + ".png"
             
             img2.save(fname)
             print("Screenshot taken")
+
+            self.ref_img = img2
 
         root.after(5, self.take_screenshots)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It shall help when taking class online and need to take screenshot of every slid
 pyqt5
 pyscreenshot
 pillow
+imgcompare
 ```
 It can also install by running following in terminal.
 ```
@@ -19,6 +20,10 @@ pip install -r requirements.txt
 4. Click ```Start``` and draw rectangular part on screen
 5. Now it shall take screenshot when any slides in ppt changes automatically.
 6. Close the program when not needed
+
+# Notes
+
+Image comparison algorithm uses the imgcompare library. The default tolerance value is set to 5.0, you can set it by editing the code.
 
 
 # Demo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyqt5
 pyscreenshot
 pillow
+imgcompare


### PR DESCRIPTION
Hi! I like your program and I have used it for online presentations. It is very useful, thank you for making it.

I noticed that during zoom calls, the getbbox() function falsely detects changes of the slide. I believe it is due to h.264 streaming artifacts from streaming said video.

I found imgcompare from pip and found it to be useful the program as it allows for tolerance for the image differences. Said tolerances can account for the streaming artifacts. I've set it to 5, and i think maybe we can set a GUI option for this.